### PR TITLE
feat: add jot bench command with JMH support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/target
+target/
 .DS_Store
 .vscode/settings.json
+samples/**/target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,11 +636,11 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1079,6 +1095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,6 +1372,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1364,7 +1387,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1415,6 +1437,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1488,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2163,15 +2229,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ flate2 = "1.1.1"
 fs2 = "0.4.3"
 hex = "0.4.3"
 indicatif = "0.17.11"
-reqwest = { version = "0.12.15", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+reqwest = { version = "0.12.15", default-features = false, features = ["blocking", "json", "rustls-tls-native-roots"] }
 quick-xml = { version = "0.38.1", features = ["serialize"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/crates/jot-builder/src/doc.rs
+++ b/crates/jot-builder/src/doc.rs
@@ -37,22 +37,23 @@ pub(crate) fn run_dokka(
         .collect::<Result<_, _>>()?;
 
     // 2. Collect source roots that exist
-    let source_roots: Vec<&PathBuf> = project
-        .source_dirs
-        .iter()
-        .filter(|d| d.exists())
-        .collect();
+    let source_roots: Vec<&PathBuf> = project.source_dirs.iter().filter(|d| d.exists()).collect();
     if source_roots.is_empty() {
         return Err(BuildError::NoSources(project.project_root.clone()));
     }
 
     // 3. Write Dokka JSON config
     let config = build_config(project, &source_roots, classpath, &plugin_jars, docs_dir);
-    let config_path = project.project_root.join("target").join("dokka-config.json");
+    let config_path = project
+        .project_root
+        .join("target")
+        .join("dokka-config.json");
     std::fs::write(
         &config_path,
-        serde_json::to_string_pretty(&config)
-            .map_err(|e| BuildError::CommandFailed { tool: "dokka", stderr: e.to_string() })?,
+        serde_json::to_string_pretty(&config).map_err(|e| BuildError::CommandFailed {
+            tool: "dokka",
+            stderr: e.to_string(),
+        })?,
     )?;
 
     // 4. Run Dokka (suppress verbose progress output; show stderr only on failure)

--- a/crates/jot-builder/src/errors.rs
+++ b/crates/jot-builder/src/errors.rs
@@ -56,6 +56,8 @@ pub enum BuildError {
     MissingKotlinToolchain(PathBuf),
     #[error("could not locate junit-platform-console-standalone in resolved test dependencies")]
     MissingJUnitConsole,
+    #[error("could not locate jmh-generator-annprocess in resolved bench dependencies")]
+    MissingJmhAnnotationProcessor,
     #[error("{tool} failed: {stderr}")]
     CommandFailed { tool: &'static str, stderr: String },
     #[error("{tool} exited with status {code:?}")]

--- a/crates/jot-builder/src/lib.rs
+++ b/crates/jot-builder/src/lib.rs
@@ -18,12 +18,16 @@ use jot_config::{ProjectBuildConfig, load_project_build_config};
 use jot_resolver::{MavenResolver, ResolvedArtifact};
 use jot_toolchain::{InstalledJdk, InstalledKotlin, ToolchainManager};
 
-use compile::{build_compiler_chain, compile_pipeline, resolve_annotation_processing};
+use compile::{
+    AnnotationProcessingConfig, build_compiler_chain, compile_pipeline,
+    resolve_annotation_processing,
+};
 use package::{build_fat_jar, copy_resources, package_jar};
 
 const DEFAULT_RESOLVE_DEPTH: usize = 8;
 const DEFAULT_JUNIT_CONSOLE_COORD: &str =
     "org.junit.platform:junit-platform-console-standalone:6.0.3";
+const DEFAULT_JMH_VERSION: &str = "1.37";
 
 #[derive(Debug)]
 pub struct JavaProjectBuilder {
@@ -326,6 +330,191 @@ impl JavaProjectBuilder {
         })
     }
 
+    pub fn bench(
+        &self,
+        start: &Path,
+        filter: Option<&str>,
+        forks: u32,
+        warmup: Option<u32>,
+        iterations: Option<u32>,
+    ) -> Result<BenchOutput, BuildError> {
+        let project = load_project_build_config(start)?;
+        let mut cache = HashMap::<PathBuf, BuildOutput>::new();
+        let mut stack = Vec::<PathBuf>::new();
+        let mut path_dependency_jars = Vec::new();
+        for dependency_root in &project.path_dependencies {
+            let dependency_project = load_project_build_config(dependency_root)?;
+            let dependency_output =
+                self.build_project_with_cache(dependency_project, &mut cache, &mut stack)?;
+            path_dependency_jars.push(dependency_output.jar_path.clone());
+        }
+
+        let toolchain_request = project
+            .toolchain
+            .clone()
+            .ok_or_else(|| BuildError::MissingJavaToolchain(project.config_path.clone()))?;
+        let installed_jdk = self.toolchains.ensure_installed(&toolchain_request)?;
+
+        let installed_kotlin = match &project.kotlin_toolchain {
+            Some(request) => Some(self.toolchains.ensure_kotlin_installed(request)?),
+            None => None,
+        };
+
+        let jmh_version = project
+            .bench
+            .jmh_version
+            .as_deref()
+            .unwrap_or(DEFAULT_JMH_VERSION);
+        let jmh_core_coord = format!("org.openjdk.jmh:jmh-core:{jmh_version}");
+        let jmh_annprocess_coord =
+            format!("org.openjdk.jmh:jmh-generator-annprocess:{jmh_version}");
+
+        let compile_dependencies = self
+            .resolver
+            .resolve_artifacts(&project.dependencies, DEFAULT_RESOLVE_DEPTH)?;
+
+        let mut jmh_dep_inputs = vec![jmh_core_coord, jmh_annprocess_coord];
+        jmh_dep_inputs.extend(project.bench.deps.iter().cloned());
+        let jmh_dependencies = self
+            .resolver
+            .resolve_artifacts(&jmh_dep_inputs, DEFAULT_RESOLVE_DEPTH)?;
+
+        let target_dir = project.project_root.join("target");
+        let classes_dir = target_dir.join("classes");
+        prepare_directory(&classes_dir)?;
+
+        let main_java_sources = jot_common::collect_files_by_ext(&project.source_dirs, "java");
+        let main_kotlin_sources = jot_common::collect_files_by_ext(&project.source_dirs, "kt");
+
+        let jvm_target = project
+            .toolchain
+            .as_ref()
+            .map(|value| value.version.as_str());
+
+        if !main_java_sources.is_empty() || !main_kotlin_sources.is_empty() {
+            let main_compile_classpath = ClasspathAssembler::new()
+                .with_artifacts(&compile_dependencies)
+                .with_paths(path_dependency_jars.iter().cloned())
+                .with_optional_unique_path(kotlin_stdlib_jar(installed_kotlin.as_ref()))
+                .build();
+
+            let annotation_processing =
+                resolve_annotation_processing(&project, &self.resolver, &target_dir)?;
+            let main_compilers = build_compiler_chain(
+                installed_kotlin.as_ref(),
+                &installed_jdk,
+                Some(project.source_dirs.as_slice()),
+                annotation_processing,
+            );
+            compile_pipeline(
+                &main_compilers,
+                &project.source_dirs,
+                &main_compile_classpath,
+                &classes_dir,
+                &project.project_root,
+                jvm_target,
+            )?;
+
+            copy_resources(&project.resource_dir, &classes_dir)?;
+        }
+
+        let bench_java_sources =
+            jot_common::collect_files_by_ext(&project.bench.source_dirs, "java");
+        let bench_kotlin_sources =
+            jot_common::collect_files_by_ext(&project.bench.source_dirs, "kt");
+
+        if bench_java_sources.is_empty() && bench_kotlin_sources.is_empty() {
+            return Ok(BenchOutput {
+                project,
+                benchmarks_found: false,
+            });
+        }
+
+        let bench_classes_dir = target_dir.join("bench-classes");
+        prepare_directory(&bench_classes_dir)?;
+
+        let bench_compile_classpath = ClasspathAssembler::new()
+            .with_paths([classes_dir.clone()])
+            .with_artifacts(&compile_dependencies)
+            .with_paths(path_dependency_jars.iter().cloned())
+            .with_artifacts(&jmh_dependencies)
+            .with_optional_unique_path(kotlin_stdlib_jar(installed_kotlin.as_ref()))
+            .build();
+
+        let jmh_annprocess_jar = jmh_dependencies
+            .iter()
+            .find(|a| a.coordinate.artifact == "jmh-generator-annprocess")
+            .map(|a| a.path.clone())
+            .ok_or(BuildError::MissingJmhAnnotationProcessor)?;
+
+        let generated_bench_sources_dir = target_dir.join("generated-bench-sources");
+        prepare_directory(&generated_bench_sources_dir)?;
+
+        let bench_ap = Some(AnnotationProcessingConfig {
+            processor_paths: vec![jmh_annprocess_jar],
+            options: std::collections::BTreeMap::new(),
+            generated_sources_dir: generated_bench_sources_dir,
+        });
+        let bench_compilers = build_compiler_chain(
+            installed_kotlin.as_ref(),
+            &installed_jdk,
+            Some(project.bench.source_dirs.as_slice()),
+            bench_ap,
+        );
+        compile_pipeline(
+            &bench_compilers,
+            &project.bench.source_dirs,
+            &bench_compile_classpath,
+            &bench_classes_dir,
+            &project.project_root,
+            jvm_target,
+        )?;
+
+        let runtime_classpath = ClasspathAssembler::new()
+            .with_paths([classes_dir, bench_classes_dir])
+            .with_artifacts(&compile_dependencies)
+            .with_paths(path_dependency_jars)
+            .with_artifacts(&jmh_dependencies)
+            .with_optional_unique_path(kotlin_stdlib_jar(installed_kotlin.as_ref()))
+            .build();
+        let classpath = std::env::join_paths(&runtime_classpath)?;
+
+        let mut cmd = Command::new(installed_jdk.java_binary());
+        cmd.current_dir(&project.project_root)
+            .arg("-cp")
+            .arg(classpath)
+            .arg("org.openjdk.jmh.Main");
+
+        if let Some(filter) = filter {
+            cmd.arg(filter);
+        }
+        cmd.args(["-f", &forks.to_string()]);
+        if let Some(w) = warmup {
+            cmd.args(["-wi", &w.to_string()]);
+        }
+        if let Some(i) = iterations {
+            cmd.args(["-i", &i.to_string()]);
+        }
+
+        let status = cmd
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+
+        if !status.success() {
+            return Err(BuildError::ProcessExit {
+                tool: "jmh",
+                code: status.code(),
+            });
+        }
+
+        Ok(BenchOutput {
+            project,
+            benchmarks_found: true,
+        })
+    }
+
     pub fn doc(&self, start: &Path) -> Result<DocOutput, BuildError> {
         let project = load_project_build_config(start)?;
         let toolchain_request = project
@@ -367,6 +556,12 @@ pub struct BuildOutput {
 pub struct TestOutput {
     pub project: ProjectBuildConfig,
     pub tests_found: bool,
+}
+
+#[derive(Debug)]
+pub struct BenchOutput {
+    pub project: ProjectBuildConfig,
+    pub benchmarks_found: bool,
 }
 
 #[derive(Debug)]

--- a/crates/jot-builder/src/lib.rs
+++ b/crates/jot-builder/src/lib.rs
@@ -441,17 +441,20 @@ impl JavaProjectBuilder {
             .with_optional_unique_path(kotlin_stdlib_jar(installed_kotlin.as_ref()))
             .build();
 
-        let jmh_annprocess_jar = jmh_dependencies
+        // Verify the annotation processor is present in the resolved deps
+        jmh_dependencies
             .iter()
             .find(|a| a.coordinate.artifact == "jmh-generator-annprocess")
-            .map(|a| a.path.clone())
             .ok_or(BuildError::MissingJmhAnnotationProcessor)?;
+
+        // All JMH deps go on processor path so jmh-generator-annprocess can load jmh-generator-core
+        let jmh_processor_paths: Vec<_> = jmh_dependencies.iter().map(|a| a.path.clone()).collect();
 
         let generated_bench_sources_dir = target_dir.join("generated-bench-sources");
         prepare_directory(&generated_bench_sources_dir)?;
 
         let bench_ap = Some(AnnotationProcessingConfig {
-            processor_paths: vec![jmh_annprocess_jar],
+            processor_paths: jmh_processor_paths,
             options: std::collections::BTreeMap::new(),
             generated_sources_dir: generated_bench_sources_dir,
         });
@@ -534,7 +537,13 @@ impl JavaProjectBuilder {
             .with_artifacts(&dependencies)
             .build();
 
-        doc::run_dokka(&self.resolver, &installed_jdk, &project, &classpath, &docs_dir)?;
+        doc::run_dokka(
+            &self.resolver,
+            &installed_jdk,
+            &project,
+            &classpath,
+            &docs_dir,
+        )?;
 
         Ok(DocOutput { project, docs_dir })
     }

--- a/crates/jot-config/src/lib.rs
+++ b/crates/jot-config/src/lib.rs
@@ -15,8 +15,8 @@ pub use discovery::{
 pub use editing::{DependencySpec, add_dependency, pin_java_toolchain, remove_dependency};
 pub use errors::ConfigError;
 pub use models::{
-    FormatConfig, JavaFormatStyle, LintConfig, ProjectBuildConfig, PublishConfig, PublishDeveloper,
-    WorkspaceBuildConfig, WorkspaceDependencySet, WorkspaceMemberBuildConfig,
+    BenchConfig, FormatConfig, JavaFormatStyle, LintConfig, ProjectBuildConfig, PublishConfig,
+    PublishDeveloper, WorkspaceBuildConfig, WorkspaceDependencySet, WorkspaceMemberBuildConfig,
     WorkspaceMemberDependencies,
 };
 
@@ -31,7 +31,8 @@ use crate::dependencies::{
 };
 use crate::models::WorkspaceInheritance;
 use crate::raw::{
-    RawConfig, RawFormat, RawJavaToolchain, RawLint, RawPublish, RawPublishDeveloper, RawToolchains,
+    RawBench, RawConfig, RawFormat, RawJavaToolchain, RawLint, RawPublish, RawPublishDeveloper,
+    RawToolchains,
 };
 
 pub fn load_project_build_config(start: &Path) -> Result<ProjectBuildConfig, ConfigError> {
@@ -271,6 +272,7 @@ fn load_project_build_config_from_file_with_inheritance(
         publish: parse_publish_config(config.publish, inherited_publish),
         format: parse_format_config(config.format, inherited_format),
         lint: parse_lint_config(config.lint, inherited_lint, &project_root),
+        bench: parse_bench_config(config.bench, has_kotlin, &project_root),
     })
 }
 
@@ -320,6 +322,27 @@ fn parse_lint_config(
         config.pmd_ruleset = Some(config_root.join(pmd_ruleset));
     }
     config
+}
+
+fn parse_bench_config(raw: Option<RawBench>, has_kotlin: bool, root: &Path) -> BenchConfig {
+    let raw = raw.unwrap_or_default();
+    let source_dirs = raw
+        .source_dirs
+        .unwrap_or_else(|| {
+            let mut dirs = vec!["src/bench/java".to_owned()];
+            if has_kotlin {
+                dirs.push("src/bench/kotlin".to_owned());
+            }
+            dirs
+        })
+        .into_iter()
+        .map(|v| root.join(v))
+        .collect();
+    BenchConfig {
+        jmh_version: raw.jmh_version,
+        source_dirs,
+        deps: raw.deps.unwrap_or_default(),
+    }
 }
 
 fn parse_publish_config(
@@ -927,6 +950,7 @@ junit = "org.junit.jupiter:junit-jupiter:5.11.0"
                 publish: None,
                 format: FormatConfig::default(),
                 lint: LintConfig::default(),
+                bench: Default::default(),
             },
         };
 

--- a/crates/jot-config/src/models.rs
+++ b/crates/jot-config/src/models.rs
@@ -23,6 +23,14 @@ pub struct LintConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BenchConfig {
+    /// Override the JMH version pinned in jot. If `None`, jot's default is used.
+    pub jmh_version: Option<String>,
+    pub source_dirs: Vec<PathBuf>,
+    pub deps: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PublishConfig {
     pub license: Option<String>,
     pub description: Option<String>,
@@ -59,6 +67,7 @@ pub struct ProjectBuildConfig {
     pub publish: Option<PublishConfig>,
     pub format: FormatConfig,
     pub lint: LintConfig,
+    pub bench: BenchConfig,
 }
 
 impl ProjectBuildConfig {

--- a/crates/jot-config/src/raw.rs
+++ b/crates/jot-config/src/raw.rs
@@ -15,6 +15,7 @@ pub(crate) struct RawConfig {
     pub(crate) publish: Option<RawPublish>,
     pub(crate) format: Option<RawFormat>,
     pub(crate) lint: Option<RawLint>,
+    pub(crate) bench: Option<RawBench>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -103,6 +104,15 @@ pub(crate) struct RawFormat {
 pub(crate) struct RawLint {
     #[serde(rename = "pmd-ruleset")]
     pub(crate) pmd_ruleset: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub(crate) struct RawBench {
+    #[serde(rename = "jmh-version")]
+    pub(crate) jmh_version: Option<String>,
+    #[serde(rename = "source-dirs")]
+    pub(crate) source_dirs: Option<Vec<String>>,
+    pub(crate) deps: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/jot/src/cli.rs
+++ b/crates/jot/src/cli.rs
@@ -114,6 +114,21 @@ pub(crate) enum Command {
         #[arg(long)]
         module: Option<String>,
     },
+    Bench {
+        /// Benchmark name filter regex (e.g. "MyBench", ".*sort.*")
+        filter: Option<String>,
+        #[arg(long)]
+        module: Option<String>,
+        /// Number of measurement iterations (default: JMH default = 5)
+        #[arg(long)]
+        iterations: Option<u32>,
+        /// Number of warmup iterations (default: JMH default = 5)
+        #[arg(long)]
+        warmup: Option<u32>,
+        /// Number of JVM forks (default: 1)
+        #[arg(long, default_value_t = 1)]
+        forks: u32,
+    },
     Doc {
         #[arg(long)]
         module: Option<String>,

--- a/crates/jot/src/commands/bench.rs
+++ b/crates/jot/src/commands/bench.rs
@@ -1,0 +1,42 @@
+use jot_builder::JavaProjectBuilder;
+use jot_cache::JotPaths;
+use jot_resolver::MavenResolver;
+use jot_toolchain::ToolchainManager;
+
+use crate::commands::render::{StatusTone, print_status_stdout};
+
+pub(crate) fn handle_bench(
+    paths: JotPaths,
+    manager: ToolchainManager,
+    module: Option<&str>,
+    filter: Option<&str>,
+    forks: u32,
+    warmup: Option<u32>,
+    iterations: Option<u32>,
+) -> Result<(), anyhow::Error> {
+    let resolver = MavenResolver::new(paths)?;
+    let builder = JavaProjectBuilder::new(resolver, manager);
+    let targets = super::select_project_targets(module)?;
+    let roots = match targets {
+        super::ProjectTargets::Workspace { roots } => roots,
+        super::ProjectTargets::Single { root } => vec![root],
+    };
+
+    for project_root in roots {
+        let output = builder.bench(&project_root, filter, forks, warmup, iterations)?;
+        if output.benchmarks_found {
+            print_status_stdout(
+                "bench",
+                StatusTone::Success,
+                format!("completed for {}", output.project.name),
+            );
+        } else {
+            print_status_stdout(
+                "bench",
+                StatusTone::Dim,
+                format!("no benchmark sources found for {}", output.project.name),
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/jot/src/commands/mod.rs
+++ b/crates/jot/src/commands/mod.rs
@@ -8,6 +8,7 @@ use jot_toolchain::ToolchainManager;
 use crate::cli::{Cli, Command};
 
 pub(crate) mod audit;
+pub(crate) mod bench;
 pub(crate) mod build;
 pub(crate) mod deps;
 pub(crate) mod project;
@@ -89,6 +90,21 @@ pub(crate) fn run() -> anyhow::Result<()> {
         Command::Resolve { dependency, deps } => deps::handle_resolve(&dependency, deps)?,
         Command::Run { module, args } => run::handle_run(paths, manager, module.as_deref(), &args)?,
         Command::Test { module } => run::handle_test(paths, manager, module.as_deref())?,
+        Command::Bench {
+            filter,
+            module,
+            iterations,
+            warmup,
+            forks,
+        } => bench::handle_bench(
+            paths,
+            manager,
+            module.as_deref(),
+            filter.as_deref(),
+            forks,
+            warmup,
+            iterations,
+        )?,
         Command::Doc { module, open } => build::handle_doc(paths, manager, module.as_deref(), open)?,
         Command::SelfCmd(command) => self_mgmt::handle_self(command, paths)?,
         Command::Tree {

--- a/crates/jot/src/commands/mod.rs
+++ b/crates/jot/src/commands/mod.rs
@@ -105,7 +105,9 @@ pub(crate) fn run() -> anyhow::Result<()> {
             warmup,
             iterations,
         )?,
-        Command::Doc { module, open } => build::handle_doc(paths, manager, module.as_deref(), open)?,
+        Command::Doc { module, open } => {
+            build::handle_doc(paths, manager, module.as_deref(), open)?
+        }
         Command::SelfCmd(command) => self_mgmt::handle_self(command, paths)?,
         Command::Tree {
             dependency,

--- a/crates/jot/src/commands/publish.rs
+++ b/crates/jot/src/commands/publish.rs
@@ -924,6 +924,7 @@ mod tests {
             }),
             format: Default::default(),
             lint: Default::default(),
+            bench: Default::default(),
         };
         let coordinate = MavenCoordinate {
             group: "io.github.demo".into(),
@@ -1006,6 +1007,7 @@ mod tests {
             }),
             format: Default::default(),
             lint: Default::default(),
+            bench: Default::default(),
         };
         let build = BuildOutput {
             project,

--- a/samples/java/benchmarks/jot.toml
+++ b/samples/java/benchmarks/jot.toml
@@ -1,0 +1,13 @@
+[project]
+name = "benchmarks"
+version = "0.1.0"
+
+[toolchains]
+java = "21"
+
+# [bench] is optional — jot pins JMH 1.37 and provides src/bench/java by default.
+# Uncomment to override:
+# [bench]
+# jmh-version = "1.37"
+# source-dirs = ["src/bench/java"]
+# deps = []

--- a/samples/java/benchmarks/src/bench/java/com/example/StringConcatBenchmark.java
+++ b/samples/java/benchmarks/src/bench/java/com/example/StringConcatBenchmark.java
@@ -1,0 +1,30 @@
+package com.example;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class StringConcatBenchmark {
+
+    @Benchmark
+    public String plusConcat() {
+        return "Hello" + ", " + "world!";
+    }
+
+    @Benchmark
+    public String builderConcat() {
+        return new StringBuilder()
+                .append("Hello")
+                .append(", ")
+                .append("world!")
+                .toString();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `jot bench` command for running JMH (Java Microbenchmark Harness) benchmarks
- Auto-injects JMH 1.37 (configurable via `[bench].jmh-version` in `jot.toml`) — users never need to know Maven coordinates
- Benchmark sources live in `src/bench/java` / `src/bench/kotlin` by default

## New CLI

```
jot bench [FILTER] [--forks N] [--warmup N] [--iterations N] [--module M]
```

## jot.toml config (all optional)

```toml
[bench]
jmh-version = "1.37"   # defaults to 1.37
source-dirs = ["src/bench/java"]
deps = ["com.google.guava:guava:33.0.0-jre"]
```

## Sample output

```
Benchmark                            Mode  Cnt  Score   Error  Units
StringConcatBenchmark.builderConcat  avgt       5.162          ns/op
StringConcatBenchmark.plusConcat     avgt       0.324          ns/op
BENCH completed for benchmarks
```

## Bug fixes also in this PR

- **TLS**: switched `reqwest` from `rustls-tls` to `rustls-tls-native-roots` so jot respects the system CA certificate store (fixes failures behind corporate TLS-inspection proxies)
- **Annotation processor**: all resolved JMH deps are now on javac's `-processorpath` so `jmh-generator-annprocess` can load its own transitive dependency `jmh-generator-core`

## Test plan

- [x] `cargo test --workspace` passes (87 tests)
- [x] `jot bench --warmup 1 --iterations 1 --forks 1` runs successfully in `samples/java/benchmarks`
- [ ] Verify on a project with `[bench].deps` extra dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)